### PR TITLE
Add debug logging to SNS

### DIFF
--- a/lib/sns.js
+++ b/lib/sns.js
@@ -25,10 +25,10 @@ function SnsClient() {
 
 SnsClient.prototype.start = function start() {
     if (!config.get('awsKey') || !config.get('awsSecret')) {
-        // skip init if no AWS keys
+        console.log('Skipping SNS initialization...');
         return Promise.resolve();
     }
-
+    console.log('Initializing SNS in region:', config.get('awsRegion'));
     this.sns = new AWS.SNS({region: config.get('awsRegion')});
 
     const sources = config.get('queryDataSources'),
@@ -46,7 +46,8 @@ SnsClient.prototype.start = function start() {
 };
 
 SnsClient.prototype.createTopic = function createTopic(topicName) {
-    return this.sns.createTopic({Name: topicName}, (err, result) => {
+    console.log('Creating SNS topic:', topicName);
+    this.sns.createTopic({Name: topicName}, (err, result) => {
         if (err) {
             return Promise.reject(err);
         }
@@ -57,7 +58,7 @@ SnsClient.prototype.createTopic = function createTopic(topicName) {
 
 SnsClient.prototype.publish = function publish(topic, message) {
     if (!config.get('awsKey') || !config.get('awsSecret')) {
-        // skip publish if no AWS keys
+        console.log('Skipping publish to SNS...');
         return Promise.resolve();
     }
 
@@ -66,7 +67,8 @@ SnsClient.prototype.publish = function publish(topic, message) {
             TopicArn: this.topics[topicName],
             Message: message
         };
-    return this.sns.publish(publishParams, (err) => {
+    console.log('Publishing to SNS topic:', topic);
+    this.sns.publish(publishParams, (err) => {
         if (err) {
             return Promise.reject(err);
         }


### PR DESCRIPTION
When running locally, the SNS topics get created correctly. When deployed through Harbor, none of the SNS topics get created. Adding additional logging for insight.