### PR TITLE
Add whole doc in message to avoid looking it up again downstream

### DIFF
--- a/tasks/retrieve-content.js
+++ b/tasks/retrieve-content.js
@@ -87,7 +87,8 @@ Promise.all([amqp.start(), sns.start(), messenger.start()])
                             },
                             event: {
                                 source: doc.dataSource,
-                                record
+                                record,
+                                doc
                             }
                         });
 


### PR DESCRIPTION
This is a non-breaking change for convenience.

Embed doc in message to avoid clients having to look it up again.

This only changes the new message published via CNN-messaging.