### PR TITLE
Add id to payload

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cnn-town-crier",
-  "version": "2.4.1",
+  "version": "2.4.2",
   "description": "CNN Town Crier",
   "main": "server.js",
   "directories": {

--- a/tasks/retrieve-content.js
+++ b/tasks/retrieve-content.js
@@ -54,6 +54,7 @@ Promise.all([amqp.start(), sns.start(), messenger.start()])
                     contentType: doc.type,
                     schemaVersion: '2.1.0',
                     slug: doc.slug,
+                    id: doc.id,
                     sourceId: doc.sourceId,
                     url: doc.url,
                     firstPublishDate: doc.firstPublishDate,

--- a/tasks/retrieve-content.js
+++ b/tasks/retrieve-content.js
@@ -54,7 +54,6 @@ Promise.all([amqp.start(), sns.start(), messenger.start()])
                     contentType: doc.type,
                     schemaVersion: '2.1.0',
                     slug: doc.slug,
-                    id: doc.id,
                     sourceId: doc.sourceId,
                     url: doc.url,
                     firstPublishDate: doc.firstPublishDate,
@@ -89,6 +88,7 @@ Promise.all([amqp.start(), sns.start(), messenger.start()])
                             event: {
                                 source: doc.dataSource,
                                 section: doc.section,
+                                id: doc.id,
                                 record
                             }
                         });


### PR DESCRIPTION
Why
---
Upstream systems that consume content and should want to be notified of changes may use the id (e.g. h_defa33294e9bffc5a78256f63d4bd461 ) instead of sourceID to identify their content. This saves them performing a lookup on sourceId or keeping a mapping of their own. 