### PR TITLE
Feature/unified message

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cnn-town-crier",
-  "version": "2.5.1",
+  "version": "2.5.0",
   "description": "CNN Town Crier",
   "main": "server.js",
   "directories": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cnn-town-crier",
-  "version": "2.4.4",
+  "version": "2.4.5",
   "description": "CNN Town Crier",
   "main": "server.js",
   "directories": {

--- a/tasks/retrieve-content.js
+++ b/tasks/retrieve-content.js
@@ -50,7 +50,7 @@ Promise.all([amqp.start(), sns.start(), messenger.start()])
             cr.getRecentPublishes(config.get('queryLimit'), config.get('queryContentTypes'), config.get('queryDataSources')).then((response) => {
                 response.docs.forEach((doc) => {
                     const record = {
-                        branding: (doc.attributes) ? doc.attributes.branding : '',
+                        branding: (doc.attributes) ? doc.attributes.branding : doc.branding || '',
                         contentType: doc.type,
                         schemaVersion: '2.1.0',
                         slug: doc.slug,

--- a/tasks/retrieve-content.js
+++ b/tasks/retrieve-content.js
@@ -50,11 +50,13 @@ Promise.all([amqp.start(), sns.start(), messenger.start()])
         cr.getRecentPublishes(config.get('queryLimit'), config.get('queryContentTypes'), config.get('queryDataSources')).then((response) => {
             response.docs.forEach((doc) => {
                 const record = {
-                    branding: (doc.attributes) ? doc.attributes.branding : '',
+                    branding: doc.branding || ((doc.attributes) ? doc.attributes.branding : ''),
                     contentType: doc.type,
                     schemaVersion: '2.1.0',
                     slug: doc.slug,
+                    section: doc.section,
                     sourceId: doc.sourceId,
+                    source: doc.dataSource,
                     url: doc.url,
                     firstPublishDate: doc.firstPublishDate,
                     lastModifiedDate: doc.lastModifiedDate
@@ -85,13 +87,7 @@ Promise.all([amqp.start(), sns.start(), messenger.start()])
                                 objectId: doc.sourceId,
                                 action: 'update'
                             },
-                            event: {
-                                source: doc.dataSource,
-                                section: doc.section,
-                                id: doc.id,
-                                branding: doc.branding,
-                                record
-                            }
+                            event: record
                         });
 
                     if (!dbRecord) {

--- a/tasks/retrieve-content.js
+++ b/tasks/retrieve-content.js
@@ -52,7 +52,7 @@ Promise.all([amqp.start(), sns.start(), messenger.start()])
                 const record = {
                     branding: doc.branding || ((doc.attributes) ? doc.attributes.branding : ''),
                     contentType: doc.type,
-                    schemaVersion: '2.1.0',
+                    schemaVersion: '2.1.1',
                     slug: doc.slug,
                     section: doc.section,
                     sourceId: doc.sourceId,

--- a/tasks/retrieve-content.js
+++ b/tasks/retrieve-content.js
@@ -52,6 +52,7 @@ Promise.all([amqp.start(), sns.start(), messenger.start()])
                 const record = {
                     branding: doc.branding || ((doc.attributes) ? doc.attributes.branding : ''),
                     contentType: doc.type,
+                    id: doc.id,
                     schemaVersion: '2.1.1',
                     slug: doc.slug,
                     section: doc.section,


### PR DESCRIPTION
The purpose of this is to get the same information across both mercury and sns without breaking any existing lambdas. 

To do so the fields sent are now synced in the 'record' variable, which is an additive and non breaking change for any SNS subscribers. The EventMessage for mercury now uses the record as its event, with all of the original fields and a few more. 